### PR TITLE
Fix JBoss 7.1 VFS URL protocol

### DIFF
--- a/annotation-detector/src/main/java/eu/infomas/annotation/AnnotationDetector.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/AnnotationDetector.java
@@ -257,7 +257,7 @@ public final class AnnotationDetector {
             final Enumeration<URL> resourceEnum = classLoader.getResources(internalPackageName);
             while (resourceEnum.hasMoreElements()) {
                 final URL url = resourceEnum.nextElement();
-                if ("file".equals(url.getProtocol())) {
+                if ("file".equals(url.getProtocol()) || "vfs".equals(url.getProtocol())) {
                     final File dir = toFile(url);
                     if (dir.isDirectory()) {
                         files.add(dir);


### PR DESCRIPTION
JBoss delivers resource URL's in its own VFS protocol, instead of the expected 'file' protocol. This fix processes these URL's in the same way, instead of incorrectly assuming the non-file URL is a 'jar' URL.
