### PR TITLE
Added ability to filter scanning by fileName

### DIFF
--- a/annotation-detector/src/main/java/eu/infomas/annotation/AlwaysTrueClassCheckFilter.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/AlwaysTrueClassCheckFilter.java
@@ -1,0 +1,18 @@
+package eu.infomas.annotation;
+
+/**
+ * Default implementation of {@code ClassCheckFilter} always returning true.
+ * Plugged to provide full compatibility with previous code.
+ *
+ * @author <a href="mailto:cedric@gatay.fr">Cedric Gatay</a>
+ * @since annotation-detector 3.0.2
+ */
+final class AlwaysTrueClassCheckFilter implements AnnotationDetector.ClassCheckFilter{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEligibleForScanning(final String fileName) {
+        return true;
+    }
+}

--- a/annotation-detector/src/main/java/eu/infomas/annotation/ZipFileIterator.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/ZipFileIterator.java
@@ -42,21 +42,24 @@ final class ZipFileIterator {
     
     private final ZipFile zipFile;
     private final Enumeration<? extends ZipEntry> entries;
+    private final AnnotationDetector.ClassCheckFilter classCheckFilter;
     private ZipEntry current;
-    
-    ZipFileIterator(final File file) throws IOException {
+
+    ZipFileIterator(final File file, final AnnotationDetector.ClassCheckFilter classCheckFilter) throws IOException {
         zipFile = new ZipFile(file);
         entries = zipFile.entries();
+        this.classCheckFilter = classCheckFilter;
     }
-    
+
     public ZipEntry getEntry() {
         return current;
     }
-    
+
     public InputStream next() throws IOException {
         while (entries.hasMoreElements()) {
             current = entries.nextElement();
-            if (!current.isDirectory()) {
+            if (!current.isDirectory()
+                && classCheckFilter.isEligibleForScanning(current.getName())) {
                 return zipFile.getInputStream(current);
             }
         }

--- a/annotation-detector/src/test/java/eu/infomas/annotation/AnnotationDetectorTest.java
+++ b/annotation-detector/src/test/java/eu/infomas/annotation/AnnotationDetectorTest.java
@@ -1,13 +1,13 @@
 package eu.infomas.annotation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static eu.infomas.util.TestSupport.*;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 
-import org.junit.Test;
+import static eu.infomas.util.TestSupport.*;
+import static org.junit.Assert.*;
 
 @RuntimeInvisibleTestAnnotation
 // This annotation is only used to test a complex annotation type
@@ -116,7 +116,7 @@ public final class AnnotationDetectorTest {
         if (DEBUG) log("Time: %d ms.", System.currentTimeMillis() - time);
         assertEquals(0, counter.getTypeCount());
         assertEquals(0, counter.getFieldCount());
-        assertEquals(14, counter.getMethodCount());
+        assertEquals(15, counter.getMethodCount());
     }
 
     @Test
@@ -131,7 +131,7 @@ public final class AnnotationDetectorTest {
         if (DEBUG) log("Time: %d ms.", System.currentTimeMillis() - time);
         assertEquals(0, counter.getTypeCount());
         assertEquals(0, counter.getFieldCount());
-        assertEquals(14, counter.getMethodCount());
+        assertEquals(15, counter.getMethodCount());
     }
     
     /**
@@ -154,6 +154,30 @@ public final class AnnotationDetectorTest {
         assertEquals(2, counter.getTypeCount());
         assertEquals(1, counter.getFieldCount());
         assertEquals(2, counter.getMethodCount());
+    }
+
+
+    /**
+     * Test checking ClassCheckFilter behavior when excluding detection in this class
+     */
+    @Test
+    public void testClassCheckFilterExcludesThisClass() throws IOException{
+        @SuppressWarnings("unchecked")
+        final CountingReporter counter = new CountingReporter(
+                RuntimeVisibleTestAnnotations.class,
+                RuntimeVisibleTestAnnotation.class,
+                RuntimeInvisibleTestAnnotation.class);
+        // only in this package == only this class!
+        new AnnotationDetector(counter, new AnnotationDetector.ClassCheckFilter() {
+            @Override
+            public boolean isEligibleForScanning(final String fileName) {
+                return !fileName.contains(AnnotationDetectorTest.class.getSimpleName());
+            }
+        }).detect("eu.infomas.annotation");
+
+        assertEquals(0, counter.getTypeCount());
+        assertEquals(0, counter.getFieldCount());
+        assertEquals(0, counter.getMethodCount());
     }
     
 }


### PR DESCRIPTION
To improve performances in annotation scanning, added a ClassCheckFilter interface allowing to determine if annotation
detection should proceed.
There is use cases where package names are not enough to filter out classes to scan.
