### PR TITLE
Removed recursion in ClassFileIterator to elminate stack overflows

### DIFF
--- a/annotation-detector/src/main/java/eu/infomas/annotation/ClassFileIterator.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/ClassFileIterator.java
@@ -40,95 +40,97 @@ import eu.infomas.util.FileIterator;
  */
 final class ClassFileIterator {
 
-    private final FileIterator fileIterator;
-    private ZipFileIterator zipIterator;
-    private boolean isFile;
-    
-    /**
-     * Create a new {@code ClassFileIterator} returning all Java ClassFile files
-     * available from the class path ({@code System.getProperty("java.class.path")}).
-     */
-    ClassFileIterator() throws IOException {
-        this(classPath());
-    }
-    
-    /**
-     * Create a new {@code ClassFileIterator} returning all Java ClassFile files
-     * available from the specified files and/or directories, including sub
-     * directories.
-     */
-    public ClassFileIterator(final File... filesOrDirectories) throws IOException {
-        fileIterator = new FileIterator(filesOrDirectories);
-    }
+	private final FileIterator fileIterator;
+	private ZipFileIterator zipIterator;
+	private boolean isFile;
 
-    /**
-     * Return the name of the Java ClassFile returned from the last call to
-     * {@link #next()}. The name is either the path name of a file or the name of
-     * an ZIP/JAR file entry.
-     */
-    public String getName() {
-        // Both getPath() and getName() are very light weight method calls
-        return zipIterator == null ? 
-            fileIterator.getFile().getPath() : 
-            zipIterator.getEntry().getName();
-    }
+	/**
+	 * Create a new {@code ClassFileIterator} returning all Java ClassFile files
+	 * available from the class path ({@code System.getProperty("java.class.path")}).
+	 */
+	ClassFileIterator() throws IOException {
+		this(classPath());
+	}
 
-    /**
-     * Return {@code true} if the current {@link InputStream} is reading from a
-     * plain {@link File}. Return {@code false} if the current {@link InputStream} 
-     * is reading from a ZIP File Entry.
-     */
-    public boolean isFile() {
-        return isFile;
-    }
-    
-    /**
-     * Return the next Java ClassFile as an {@code InputStream}.
-     * <br/>
-     * NOTICE: Client code MUST close the returned {@code InputStream}!
-     */
-    public InputStream next() throws IOException {
-        if (zipIterator == null) {
-            final File file = fileIterator.next();
-            if (file == null) {
-                return null;
-            } else {
-                final String name = file.getName();
-                if (name.endsWith(".class")) {
-                    isFile = true;
-                    return new FileInputStream(file);
-                } else if (fileIterator.isRootFile() && endsWithIgnoreCase(name, ".jar")) {
-                    zipIterator = new ZipFileIterator(file);
-                } // else just ignore
-                return next();
-            }
-        } else {
-            final InputStream is = zipIterator.next();
-            if (is == null) {
-                zipIterator = null;
-                return next();
-            } else {
-                isFile = false;
-                return is;
-            }
-        }
-    }
+	/**
+	 * Create a new {@code ClassFileIterator} returning all Java ClassFile files
+	 * available from the specified files and/or directories, including sub
+	 * directories.
+	 */
+	public ClassFileIterator(final File... filesOrDirectories) throws IOException {
+		fileIterator = new FileIterator(filesOrDirectories);
+	}
 
-    // private
-    
-    /** Returns the class path of the current JVM instance as an array of {@link File} objects. */
-    private static File[] classPath() {
-        final String[] fileNames = System.getProperty("java.class.path").split(File.pathSeparator);
-        final File[] files = new File[fileNames.length];
-        for (int i = 0; i < files.length; ++i) {
-            files[i] = new File(fileNames[i]);
-        }
-        return files;
-    }
-    
-    private static boolean endsWithIgnoreCase(final String value, final String suffix) {
-        final int n = suffix.length();
-        return value.regionMatches(true, value.length() - n, suffix, 0, n);
-    }
-    
+	/**
+	 * Return the name of the Java ClassFile returned from the last call to
+	 * {@link #next()}. The name is either the path name of a file or the name of
+	 * an ZIP/JAR file entry.
+	 */
+	public String getName() {
+		// Both getPath() and getName() are very light weight method calls
+		return zipIterator == null ? 
+				fileIterator.getFile().getPath() : 
+					zipIterator.getEntry().getName();
+	}
+
+	/**
+	 * Return {@code true} if the current {@link InputStream} is reading from a
+	 * plain {@link File}. Return {@code false} if the current {@link InputStream} 
+	 * is reading from a ZIP File Entry.
+	 */
+	public boolean isFile() {
+		return isFile;
+	}
+
+	/**
+	 * Return the next Java ClassFile as an {@code InputStream}.
+	 * <br/>
+	 * NOTICE: Client code MUST close the returned {@code InputStream}!
+	 */
+	public InputStream next() throws IOException {
+		while (true) {
+			if (zipIterator == null) {
+				final File file = fileIterator.next();
+				if (file == null) {
+					return null;
+				} else {
+					final String name = file.getName();
+					if (name.endsWith(".class")) {
+						isFile = true;
+						return new FileInputStream(file);
+					} else if (fileIterator.isRootFile() && endsWithIgnoreCase(name, ".jar")) {
+						zipIterator = new ZipFileIterator(file);
+					} // else just ignore
+					continue;
+				}
+			} else {
+				final InputStream is = zipIterator.next();
+				if (is == null) {
+					zipIterator = null;
+					continue;
+				} else {
+					isFile = false;
+					return is;
+				}
+			}
+		}
+	}
+
+	// private
+
+	/** Returns the class path of the current JVM instance as an array of {@link File} objects. */
+	private static File[] classPath() {
+		final String[] fileNames = System.getProperty("java.class.path").split(File.pathSeparator);
+		final File[] files = new File[fileNames.length];
+		for (int i = 0; i < files.length; ++i) {
+			files[i] = new File(fileNames[i]);
+		}
+		return files;
+	}
+
+	private static boolean endsWithIgnoreCase(final String value, final String suffix) {
+		final int n = suffix.length();
+		return value.regionMatches(true, value.length() - n, suffix, 0, n);
+	}
+
 }


### PR DESCRIPTION
When the classpath contains a directory with lots of files, ClassFileIterator will overrun the stack because it relies on recursive calls.  Rewrote next() to use a while loop instead of recursion.
