### PR TITLE
Fix an issue with classpath scanning on GlassFish 4.1.1.

### DIFF
--- a/annotation-detector/src/main/java/eu/infomas/annotation/AnnotationDetector.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/AnnotationDetector.java
@@ -299,9 +299,9 @@ public final class AnnotationDetector {
                     if (url.getProtocol().startsWith("bundle")) {
                         try {
                             final Method m = urlConnection.getClass().
-                                getDeclaredMethod("getLocalURL", (Class<?>)null);
+                                getDeclaredMethod("getLocalURL", (Class<?>[])null);
                             m.setAccessible(true);
-                            final URL jarUrl = (URL)m.invoke(urlConnection, (Class<?>)null);
+                            final URL jarUrl = (URL)m.invoke(urlConnection);
                             urlConnection = jarUrl.openConnection();
                         } catch (Exception e) {
                             throw new AssertionError("Failed processing bundle - couldn't" +


### PR DESCRIPTION
These changes fix the issue I was encountering with deployment on GlassFish - they should have no impact on the scanning mechanism for any other format (but please review)

Note that my changes are now causing the build to fail with:
AnnotationDetector.java:259:5: NPath Complexity is 276 (max allowed is 200).

I don't know why this is happening now - I didn't change any code in that area.