### PR TITLE
Allow custom ResourceIterators

### DIFF
--- a/annotation-detector/src/main/java/eu/infomas/annotation/AnnotationDetector.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/AnnotationDetector.java
@@ -370,7 +370,7 @@ public final class AnnotationDetector {
     }
 
     @SuppressWarnings("illegalcatch")
-    private void detect(final ResourceIterator iterator) throws IOException {
+    public void detect(final ResourceIterator iterator) throws IOException {
         InputStream stream;
         while ((stream = iterator.next()) != null) {
             try {

--- a/annotation-detector/src/main/java/eu/infomas/annotation/ClassFileIterator.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/ClassFileIterator.java
@@ -37,7 +37,7 @@ import java.util.zip.ZipFile;
  * @author <a href="mailto:rmuller@xiam.nl">Ronald K. Muller</a>
  * @since annotation-detector 3.0.0
  */
-final class ClassFileIterator extends ResourceIterator {
+public final class ClassFileIterator extends ResourceIterator {
 
     private final FileIterator fileIterator;
     private final String[] pkgNameFilter;
@@ -59,7 +59,7 @@ final class ClassFileIterator extends ResourceIterator {
      * defined package names are returned.
      * NOTE: package names must be defined in the native format (using '/' instead of '.').
      */
-    ClassFileIterator(final File[] filesOrDirectories, final String[] pkgNameFilter) {
+    public ClassFileIterator(final File[] filesOrDirectories, final String[] pkgNameFilter) {
         this.fileIterator = new FileIterator(filesOrDirectories);
         this.pkgNameFilter = pkgNameFilter;
     }
@@ -76,7 +76,7 @@ final class ClassFileIterator extends ResourceIterator {
     }
 
     @Override
-    InputStream next() throws IOException {
+    public InputStream next() throws IOException {
         while (true) {
             if (zipIterator == null) {
                 final File file = fileIterator.next();

--- a/annotation-detector/src/main/java/eu/infomas/annotation/ResourceIterator.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/ResourceIterator.java
@@ -31,13 +31,13 @@ import java.io.InputStream;
  * @author <a href="mailto:rmuller@xiam.nl">Ronald K. Muller</a>
  * @since INFOMAS NG 3.0
  */
-abstract class ResourceIterator {
+public abstract class ResourceIterator {
 
     /**
      * Return the next Java ClassFile as an {@code InputStream}.
      * <p>
      * NOTICE: Client code MUST close the returned {@code InputStream}!
      */
-    abstract InputStream next() throws IOException;
+    public abstract InputStream next() throws IOException;
 
 }

--- a/annotation-detector/src/main/java/eu/infomas/annotation/VfsResourceIterator.java
+++ b/annotation-detector/src/main/java/eu/infomas/annotation/VfsResourceIterator.java
@@ -60,7 +60,7 @@ final class VfsResourceIterator extends ResourceIterator {
     }
 
     @Override
-    InputStream next() throws IOException {
+    public InputStream next() throws IOException {
         while (true) {
             if (++index >= files.size()) {
                 // no files


### PR DESCRIPTION
Hi there, my application uses a combination of "normal" and generated class files.  Class data are provided as plugins which the base application does not know about until the plugin arrives.  Because of the default implementation of ResourceIterator relies on the URL to determine how to create an InputStream, it can't handle my "special" cases such as classfiles whose bytecode is never written to a file system.  By making these classes/methods public instead of package-private I am able to write my own ResourceIterator which handles all kinds of classes, which I think makes the annotation-detector much more flexible especially in "special cases" like mine.  I wonder if you would consider pulling this change in case others out there have the same situation as me?  Thanks