### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ jdk:
   - openjdk11
 # batch mode / trigger checkstyle
 script: mvn -B verify
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
